### PR TITLE
Add the Test::ReportPrereqs plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -42,3 +42,5 @@ check_all_plugins = 1
 [Prereqs / TestRequires]
 Archive::Any::Lite = 0
 Module::CPANTS::Analyse = 0
+
+[Test::ReportPrereqs]


### PR DESCRIPTION
This plugin creates a test that reports the versions of all
prerequisite modules.

This is useful when searching out errors reported via users or
failing tests on CPANTesters because the error may be in a
prerequisite module.